### PR TITLE
Pass options to original cache method calls in all cases

### DIFF
--- a/lib/rails/cache/tags/store.rb
+++ b/lib/rails/cache/tags/store.rb
@@ -34,7 +34,7 @@ module Rails
           if entry
             entry
           else
-            delete(name)
+            delete(name, options)
 
             nil
           end
@@ -54,12 +54,13 @@ module Rails
         end
 
         def exist_with_tags?(name, options = nil)
-          exist_without_tags?(name, options) && !read(name).nil?
+          exist_without_tags?(name, options) && !read(name, options).nil?
         end
 
         def read_multi_with_tags(*names)
           result = read_multi_without_tags(*names)
 
+          names.extract_options!
           names.each_with_object(Hash.new) do |name, hash|
             hash[name.to_s] = tag_set.check(result[name.to_s])
           end
@@ -82,7 +83,7 @@ module Rails
             if (entry = tag_set.check(result))
               entry
             else # result is stale
-              delete(name)
+              delete(name, options)
               fetch(name, options) { yield }
             end
           end


### PR DESCRIPTION
Hi! This PR fixes misbehaviour when using namespaced keys.

Previously, when using namespaced keys `cache.fetch` would fall into infinite recursion and cause stack overflow exception, because upon finding invalidated tag it would fail to provide options to `delete` method and subsequently remove cache key. There was a problem of the same nature with `exist?` method, which is now fixed too.

I've also added test cases to cover usage of namespaced keys.