### PR TITLE
Do not delete non-existent keys

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in rails-cache-tags.gemspec
 gemspec
 
+gem 'rack', '< 2'
+
 if ENV['DALLI']
   if ENV['DALLI'] == '2.2'
     gem 'dalli', '~> 2.2.0'

--- a/lib/rails/cache/tags/store.rb
+++ b/lib/rails/cache/tags/store.rb
@@ -29,6 +29,7 @@ module Rails
 
         def read_with_tags(name, options = nil)
           result = read_without_tags(name, options)
+          return if result.nil?
           entry = tag_set.check(result)
 
           if entry

--- a/spec/cache_tags_spec.rb
+++ b/spec/cache_tags_spec.rb
@@ -50,6 +50,11 @@ describe Rails::Cache::Tags do
       assert_blank 'foo'
     end
 
+    it 'does not delete a nonexistent key' do
+      expect(cache).not_to receive(:delete).with('not_exist_key', options)
+      expect(cache.read('not_exist_key', options)).to eq nil
+    end
+
     #it 'does not read a key if it is expired' do
     #  ttl = 0.01
     #  # dalli does not support float TTLs


### PR DESCRIPTION
Hello Alexey! 😄 

Requests correct the problem of generating unnecessary requests to delete keys, when reading non-existing keys (a frequent case for the cache)